### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
-#Contributing to Laravel Localize Middleware
+# Contributing to Laravel Localize Middleware
 
 Thanks very much for deciding to contribute to this project! The guidelines below
 give you a good idea of how to get your issue fixed, or create a solid Pull Request.
 
-##Submitting Issues
+## Submitting Issues
 
 (where appropriate)
 
@@ -11,7 +11,7 @@ give you a good idea of how to get your issue fixed, or create a solid Pull Requ
 * Include details of any exception that's been thrown
 * If you can, include any relevant code that caused the issue
 
-##Submitting Pull Requests
+## Submitting Pull Requests
 
 1. Fork the project
 2. Create a feature branch from `master`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Laravel Localize Middleware
+# Laravel Localize Middleware
 
 > Configurable localization middleware for your Laravel >=5.1 application.
 
@@ -11,7 +11,7 @@ to automatically set your application's locale using the current request. You ca
 set the locale from a request parameter, header, the current host, a cookie or
 session data.
 
-##Installation
+## Installation
 
 Install the package via Composer:
 
@@ -37,7 +37,7 @@ $ php artisan vendor:publish --provider="BenConstable\Localize\LocalizeServicePr
 
 which will create `config/localize-middleware.php`.
 
-##Usage
+## Usage
 
 Out-of-the-box, the package is configured to set the application locale using a
 request parameter called `locale` (see the next section for more info). To enable
@@ -54,7 +54,7 @@ protected $middleware = [
 It's recommended to set this middleware globally and early in the stack, but you're
 free to register it in whatever way that suits your needs.
 
-###Configuration
+### Configuration
 
 Configuration can be found at `config/localize-middleware.php`. From there, you
 can configure which localization determiner you'd like to use in your application
@@ -62,7 +62,7 @@ and set options for it. You simply have to change the `driver` option.
 
 The list of available determiners is shown below.
 
-###Determining the locale from a request parameter
+### Determining the locale from a request parameter
 
 **Driver name:** `parameter`
 
@@ -79,7 +79,7 @@ Route::group(['prefix' => '{locale}'], function () {
 });
 ```
 
-###Determining the locale from a request header
+### Determining the locale from a request header
 
 **Driver name:** `header`
 
@@ -89,7 +89,7 @@ to `Accept-Language`. You can change this using the `header` configuration optio
 *Aside:* For information on using `Accept-Language` to determine the locale,
 see [this info from the W3C](https://www.w3.org/International/questions/qa-accept-lang-locales).
 
-###Determining the locale using the current host
+### Determining the locale using the current host
 
 **Driver name:** `host`
 
@@ -97,21 +97,21 @@ This determiner sets a different application locale depending on the current hos
 You'll need to set a map of your application's locales to hosts using the `hosts`
 configuration option.
 
-###Determining the locale from a cookie
+### Determining the locale from a cookie
 
 **Driver name:** `cookie`
 
 This determiner sets the application locale from a cookie called `locale`. You can
 change this using the `cookie` configuration option.
 
-###Determining the locale from the session
+### Determining the locale from the session
 
 **Driver name:** `session`
 
 This determiner sets the application locale from a session value called `locale`.
 You can change this using the `session` configuration option.
 
-###Using multiple determiners
+### Using multiple determiners
 
 Sometimes it might be useful to try and determine the locale from more than one
 source. If you'd like to do this, just set the `driver` configuration option to an
@@ -128,7 +128,7 @@ The locale will then be deteremined from whichever determiner first provides a
 successful match, so make sure you add the drivers in the correct order (earliest
 in the array will be used first).
 
-###Determining the locale outside of middleware
+### Determining the locale outside of middleware
 
 You don't have to use the provided middleware if you don't want to. You can
 instead write your own, or avoid using middleware entirely.
@@ -153,11 +153,11 @@ $locale = Localizer::determineLocale($request);
 
 to determine the locale and do with it what you like.
 
-##Contributing
+## Contributing
 
 See [CONTRIBUTING.md](https://github.com/BenConstable/laravel-localize-middleware/blob/master/CONTRIBUTING.md).
 
-##Other Localization Projects
+## Other Localization Projects
 
 Here are some other Laravel localization projects that might be useful to you:
 
@@ -165,6 +165,6 @@ Here are some other Laravel localization projects that might be useful to you:
 * [Waavi/translation](https://github.com/Waavi/translation)
 * [caouecs/Laravel-lang](https://github.com/caouecs/Laravel-lang)
 
-##License
+## License
 
 MIT &copy; Ben Constable 2016. See [LICENSE](https://github.com/BenConstable/laravel-localize-middleware/blob/master/LICENSE) for more info.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
