### PR TITLE
Fix wrong stack processing order

### DIFF
--- a/src/Localize/Determiners/Stack.php
+++ b/src/Localize/Determiners/Stack.php
@@ -41,7 +41,7 @@ class Stack extends Determiner
             ->map(function ($determiner) use ($request) {
                 return $determiner->determineLocale($request);
             })
-            ->first(function ($index, $locale) {
+            ->first(function ($locale, $index) {
                 return $locale !== null;
             }, $this->fallback);
     }


### PR DESCRIPTION
Calling `first` on a collection triggers `Arr::first` which changes the
order of key,value when executing the callback.

See Illuminate\Support\Arr : L147