### PR TITLE
Added locale mapper

### DIFF
--- a/src/Localize/Http/Middleware/Localize.php
+++ b/src/Localize/Http/Middleware/Localize.php
@@ -53,6 +53,13 @@ class Localize
     {
         $locale = $this->determinerManager->determineLocale($request);
 
+        $localeMapper = !empty($this->app['config']['localize-middleware']['localeMapper']) ?
+            $this->app['config']['localize-middleware']['localeMapper'] : null;
+
+        if (is_callable($localeMapper)) {
+            $locale = $localeMapper($locale);
+        }
+
         $this->app->setLocale($locale);
 
         return $next($request);

--- a/src/config/localize-middleware.php
+++ b/src/config/localize-middleware.php
@@ -88,5 +88,19 @@ return [
     'hosts' => [
         'en' => 'www.example.co.uk',
         'fr' => 'www.example.fr'
-    ]
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Locale Mapping.
+    |--------------------------------------------------------------------------
+    |
+    | Define a mapping of your supported locales.
+    | en_US => en, pt_BR => pt, etc
+    |
+    */
+    'localeMapper' => function ($locale) {
+        //some custom logic
+        return $locale;
+    },
 ];


### PR DESCRIPTION
Sometimes you need to apply a filter for the locale "_pt_BR_" to "_pt_" or "_ru_UA_" to "_uk_". I implemented some callback - `localeMapper($locale)`